### PR TITLE
move to package script for not using easy_install

### DIFF
--- a/etc/init/osx/30_tools.sh
+++ b/etc/init/osx/30_tools.sh
@@ -5,20 +5,20 @@ set -eu
 source "$DOTPATH"/etc/lib/vital.sh
 
 #if is_exists "brew" && is_exists "easy_install" ; then
-if is_exists "brew"; then
-  case "$PLATFORM" in
-    osx)
-      #brew install freetype openjpeg
-      #sudo easy_install blockdiag
-      #sudo easy_install seqdiag
-      #sudo easy_install actdiag
-      #sudo easy_install nwdiag
-      brew install libtool freetype fontconfig webp gd
-      brew install graphviz
-      ;;
-    *)
-      echo "???"
-      ;;
-  esac
-fi
+#if is_exists "brew"; then
+#  case "$PLATFORM" in
+#    osx)
+#      #brew install freetype openjpeg
+#      #sudo easy_install blockdiag
+#      #sudo easy_install seqdiag
+#      #sudo easy_install actdiag
+#      #sudo easy_install nwdiag
+#      #brew install libtool freetype fontconfig webp gd
+#      #brew install graphviz
+#      ;;
+#    *)
+#      echo "???"
+#      ;;
+#  esac
+#fi
 

--- a/etc/init/osx/3_packages.sh
+++ b/etc/init/osx/3_packages.sh
@@ -23,7 +23,13 @@ PACKAGES=(\
   tree \
   watch \
   tig \
-  yarn
+  yarn \
+  libtool \
+  freetype \
+  fontconfig \
+  webp \
+  gd \
+  graphviz
 )
 for p in ${PACKAGES[@]}
 do


### PR DESCRIPTION
fix this
```
Warning: libtool-2.4.6_1 already installed
Warning: fontconfig-2.12.1_2 already installed
Error: freetype-2.7 already installed
To install this version, first `brew unlink freetype`
Error: webp-0.5.2 already installed
To install this version, first `brew unlink webp`
Error: gd-2.2.3_1 already installed
To install this version, first `brew unlink gd`
Error: /Users/takasing/.dotfiles/etc/init/osx/30_tools.sh:9 stopped
```